### PR TITLE
fix(orcid): replace substring surname matching with token-based matcher

### DIFF
--- a/oc_ds_converter/crossref/crossref_processing.py
+++ b/oc_ds_converter/crossref/crossref_processing.py
@@ -14,6 +14,7 @@ from typing import List, Optional, Tuple
 from oc_ds_converter.lib.cleaner import Cleaner
 from oc_ds_converter.lib.crossref_style_processing import CrossrefStyleProcessing
 from oc_ds_converter.lib.master_of_regex import ids_inside_square_brackets, pages_separator
+from oc_ds_converter.ra_processor import families_match
 from oc_ds_converter.oc_idmanager.oc_data_storage.storage_manager import StorageManager
 
 
@@ -334,10 +335,10 @@ class CrossrefProcessing(CrossrefStyleProcessing):
             giv_n = _norm(giv) if giv else ""
             init = _initial_from_given(giv)
 
-            # filtra candidati indice per family (tollerando containment)
+            # filtra candidati indice per family (token-subset: gestisce i cognomi
+            # composti senza che frammenti brevi come "li" matchino "gladilin")
             def fam_ok(cf: str) -> bool:
-                cf_n = _norm(cf)
-                return cf_n == fam_n or cf_n in fam_n or fam_n in cf_n
+                return families_match(cf, fam_n)
 
             cands = [(cf, cg, oc) for (cf, cg, oc) in candidates if fam_ok(cf)]
             if not cands:

--- a/oc_ds_converter/pubmed/pubmed_processing.py
+++ b/oc_ds_converter/pubmed/pubmed_processing.py
@@ -21,7 +21,7 @@ from oc_ds_converter.oc_idmanager.orcid import ORCIDManager
 from oc_ds_converter.oc_idmanager.pmid import PMIDManager
 from oc_ds_converter.pubmed.finder_nih import NIHResourceFinder
 from oc_ds_converter.pubmed.get_publishers import ExtractPublisherDOI
-from oc_ds_converter.ra_processor import RaProcessor
+from oc_ds_converter.ra_processor import RaProcessor, families_match
 
 warnings.filterwarnings("ignore", category=UserWarning, module='bs4')
 
@@ -388,7 +388,7 @@ class PubmedProcessing(RaProcessor):
                 else:
                     orcid = str(agent['ORCID'])
             if orcid:
-                orcid_manager = ORCIDManager(data=dict(), use_api_service=False)
+                orcid_manager = ORCIDManager(use_api_service=False)
                 orcid = orcid_manager.normalise(orcid, include_prefix=False)
                 orcid = orcid if orcid_manager.check_digit(orcid) else None
 
@@ -397,12 +397,11 @@ class PubmedProcessing(RaProcessor):
                     orc_n: List[str] = dict_orcid[ori].split(', ')
                     orc_f = orc_n[0].lower()
                     orc_g = orc_n[1] if len(orc_n) == 2 else None
-                    if f_name.lower() in orc_f.lower() or orc_f.lower() in f_name.lower():
+                    if families_match(f_name, orc_f):
                         if g_name and orc_g:
                             # If there are several authors with the same surname
                             if len([person for person in agents_list if 'family' in person if person['family'] if
-                                    person['family'].lower() in orc_f.lower() or orc_f.lower() in person[
-                                        'family'].lower()]) > 1:
+                                    families_match(person['family'], orc_f)]) > 1:
                                 # If there are several authors with the same surname and the same given names' initials
                                 if len([person for person in agents_list if 'given' in person if person['given'] if
                                         person['given'][0].lower() == orc_g[0].lower()]) > 1:

--- a/oc_ds_converter/ra_processor.py
+++ b/oc_ds_converter/ra_processor.py
@@ -18,6 +18,14 @@ from oc_ds_converter.lib.csvmanager import CSVManager
 from oc_ds_converter.lib.master_of_regex import orcid_pattern
 
 
+def families_match(a: str, b: str) -> bool:
+    tokens_a = {t for t in re.split(r"\s+", (a or "").strip().lower()) if t}
+    tokens_b = {t for t in re.split(r"\s+", (b or "").strip().lower()) if t}
+    if not tokens_a or not tokens_b:
+        return False
+    return tokens_a <= tokens_b or tokens_b <= tokens_a
+
+
 class RaProcessor(object):
     def __init__(
         self,
@@ -93,12 +101,11 @@ class RaProcessor(object):
                     orc_n: List[str] = dict_orcid[ori].split(', ')
                     orc_f = orc_n[0].lower()
                     orc_g = orc_n[1] if len(orc_n) == 2 else None
-                    if f_name.lower() in orc_f.lower() or orc_f.lower() in f_name.lower():
+                    if families_match(f_name, orc_f):
                         if g_name and orc_g:
                             # If there are several authors with the same surname
                             if len([person for person in agents_list if 'family' in person if person['family'] if
-                                    person['family'].lower() in orc_f.lower() or orc_f.lower() in person[
-                                        'family'].lower()]) > 1:
+                                    families_match(person['family'], orc_f)]) > 1:
                                 # If there are several authors with the same surname and the same given names' initials
                                 if len([person for person in agents_list if 'given' in person if person['given'] if
                                         person['given'][0].lower() == orc_g[0].lower()]) > 1:

--- a/test/crossref_processing_test.py
+++ b/test/crossref_processing_test.py
@@ -715,6 +715,25 @@ class TestCrossrefProcessing(unittest.TestCase):
         expected_editors_list = ['Malek, Sri Nurestri Abdul [orcid:0000-0001-6278-8559]']
         self.assertEqual((authors_strings_list, editors_strings_list), (expected_authors_list, expected_editors_list))
 
+    def test_get_agents_strings_list_short_surname_substring(self):
+        # A short index surname ("Li") must not contaminate longer surnames that
+        # merely contain it as a substring ("Gladilin", "Poggioli"). Only the
+        # genuine "Li" author may receive the ORCID.
+        authors_list = [
+            {"given": "L. K.", "family": "Gladilin", "affiliation": [], "role": "author"},
+            {"given": "L.", "family": "Poggioli", "affiliation": [], "role": "author"},
+            {"given": "L.", "family": "Li", "affiliation": [], "role": "author"},
+        ]
+        crossref_processor = CrossrefProcessing(None)
+        csv_manager = CSVManager()
+        csv_manager.data = {'doi:10.9799/ksfan.2012.25.1.105': {'Li, Liang [0000-0001-6411-6107]'}}
+        crossref_processor.orcid_index = csv_manager
+        crossref_processor.prefetch_doi_orcid_index(['10.9799/ksfan.2012.25.1.105'])
+        authors_strings_list, _ = crossref_processor.get_agents_strings_list('10.9799/ksfan.2012.25.1.105',
+                                                                             authors_list)
+        expected_authors_list = ['Gladilin, L. K.', 'Poggioli, L.', 'Li, L. [orcid:0000-0001-6411-6107]']
+        self.assertEqual(authors_strings_list, expected_authors_list)
+
     def test_id_worker(self):
         field_issn = 'ISSN 1050-124X'
         field_isbn = ['978-1-56619-909-4']

--- a/test/pubmed_processing_test.py
+++ b/test/pubmed_processing_test.py
@@ -301,6 +301,17 @@ class TestPubmedProcessing(unittest.TestCase):
         ag = pubmed_processor.get_agents_strings_list("10.3000/1000000001", agents_list)
         self.assertEqual(ag[0], ['Moretti, Arianna [orcid:0000-0001-5486-7070]', 'Peroni, Silvio [orcid:0000-0003-0530-4305]', 'Di Giambattista, Chiara [orcid:0000-0001-8665-095X]'] )
 
+    def test_get_agents_strings_list_orcid_in_agent(self):
+        # Agents carrying an 'orcid' key (possibly None) must not crash and must
+        # keep the valid ORCID without overwriting it.
+        pubmed_processor = PubmedProcessing(orcid_index=None)
+        agents_list = [
+            {'role': 'author', 'family': 'Peroni', 'given': 'Silvio', 'orcid': '0000-0003-0530-4305'},
+            {'role': 'author', 'family': 'Moretti', 'given': 'Arianna', 'orcid': None},
+        ]
+        ag = pubmed_processor.get_agents_strings_list("10.0000/none", agents_list)
+        self.assertEqual(ag[0], ['Peroni, Silvio [orcid:0000-0003-0530-4305]', 'Moretti, Arianna'])
+
     def test_get_venue_name_with_extended_map(self):
         item = {
              "journal": "Biochim Biophys Acta"}


### PR DESCRIPTION
The DOI->ORCID index matching used bidirectional substring containment, so a short indexed surname like "Li" matched every co-author whose surname merely contained it ("Gladilin", "Poggioli", "Zwalinski"...). Combined with the given-name initial fallback this smeared a single ORCID across many distinct people in large collaborations. Replace containment with token-subset matching (families_match), so compound surnames still match while short fragments no longer do.

Also drop the invalid data= argument from the ORCIDManager call in the Pubmed processor, which crashed whenever an agent carried an explicit orcid key.

The Datacite processor shares the containment logic but is deliberately left untouched to avoid conflicts with ongoing work on it.